### PR TITLE
Create STAC token notebook

### DIFF
--- a/tutorials/stac_token.ipynb
+++ b/tutorials/stac_token.ipynb
@@ -27,7 +27,7 @@
     "import requests\n",
     "\n",
     "\n",
-    "base_url = \"http://localhost:8080/api/v1/\"\n",
+    "base_url = \"https://api.carbonmapper.org/api/v1/\"\n",
     "\n",
     "# Request an account token\n",
     "account_token_path = \"token/pair\"\n",

--- a/tutorials/stac_token.ipynb
+++ b/tutorials/stac_token.ipynb
@@ -1,0 +1,92 @@
+{
+ "cells": [
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": [
+    "# Requesting a scoped API Token With STAC Privileges\n",
+    "\n",
+    "In this tutorial, we will request an access token from the platform API, and then request a scoped API token with STAC privileges from the [create STAC token](https://api.carbonmapper.org/api/v1/docs#/Account/account_api_token_tokens_create_stac) endpoint.\n",
+    "\n",
+    "Endpoint access levels are determined by token scopes. While some endpoints are entirely public and others private, some others return different results depending on the authorization afforded by the token scope and the group that the account belongs to. The default scopes provided to a newly registered account are _STAC_ and _catalog:read_, and will belong to the _Public_ group. Information about public, catalog, and STAC endpoints can be found in the [Carbon Mapper platform API documentation](https://carbonmapper.org/api/v1/docs/).\n",
+    "\n",
+    "A Carbon Mapper platform account [registration](https://platform.carbonmapper.org/account/register/) is required in order to request the access token used to grant the scoped API token."
+   ],
+   "id": "b4fe2ffde6eb93d3"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": [
+    "import getpass\n",
+    "import json\n",
+    "from datetime import datetime, timedelta\n",
+    "\n",
+    "import requests\n",
+    "\n",
+    "\n",
+    "base_url = \"http://localhost:8080/api/v1/\"\n",
+    "\n",
+    "# Request an account token\n",
+    "account_token_path = \"token/pair\"\n",
+    "account_email = input(\"Enter the email address associated with your Carbon Mapper account: \")\n",
+    "account_password = getpass.getpass(\"Enter the password associated with your Carbon Mapper account: \")\n",
+    "payload = {\n",
+    "    \"email\": account_email,\n",
+    "    \"password\": account_password,\n",
+    "}\n",
+    "\n",
+    "response = requests.post(\n",
+    "    f\"{base_url}{account_token_path}\",\n",
+    "    json=payload,\n",
+    ")\n",
+    "response.raise_for_status()\n",
+    "\n",
+    "access_token = response.json()[\"access\"]\n",
+    "\n",
+    "# Request a scoped token with STAC privileges\n",
+    "stac_token_path = \"account/tokens/create-stac\"\n",
+    "stac_token_name = input(\"Enter the token name: \")\n",
+    "# The token should expire one week from today\n",
+    "expiration_date = datetime.now() + timedelta(days=7)\n",
+    "payload = {\n",
+    "    \"expiration_date\": expiration_date.strftime(\"%Y-%m-%d\"),\n",
+    "    \"name\": stac_token_name,\n",
+    "}\n",
+    "\n",
+    "response = requests.post(\n",
+    "    f\"{base_url}{stac_token_path}\",\n",
+    "    json=payload,\n",
+    "    headers={\"Authorization\": f\"Bearer {access_token}\"},\n",
+    ")\n",
+    "response.raise_for_status()\n",
+    "\n",
+    "print(json.dumps(response.json(), indent=4))"
+   ],
+   "id": "2495a407c06be64a"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tutorials/stac_token.ipynb
+++ b/tutorials/stac_token.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "Endpoint access levels are determined by token scopes. While some endpoints are entirely public and others private, some others return different results depending on the authorization afforded by the token scope and the group that the account belongs to. The default scopes provided to a newly registered account are _STAC_ and _catalog:read_, and will belong to the _Public_ group. Information about public, catalog, and STAC endpoints can be found in the [Carbon Mapper platform API documentation](https://carbonmapper.org/api/v1/docs/).\n",
     "\n",
-    "A Carbon Mapper platform account [registration](https://platform.carbonmapper.org/account/register/) is required in order to request the access token used to grant the scoped API token."
+    "Users with Carbon Mapper platform accounts may obtain a scoped token. Users without accounts can [register](https://platform.carbonmapper.org/account/register/) on the Carbon Mapper platform website. "
    ],
    "id": "b4fe2ffde6eb93d3"
   },

--- a/tutorials/stac_token.ipynb
+++ b/tutorials/stac_token.ipynb
@@ -1,8 +1,9 @@
 {
  "cells": [
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "id": "b4fe2ffde6eb93d3",
+   "metadata": {},
    "source": [
     "# Requesting a scoped API Token With STAC Privileges\n",
     "\n",
@@ -10,15 +11,17 @@
     "\n",
     "Endpoint access levels are determined by token scopes. While some endpoints are entirely public and others private, some others return different results depending on the authorization afforded by the token scope and the group that the account belongs to. The default scopes provided to a newly registered account are _STAC_ and _catalog:read_, and will belong to the _Public_ group. Information about public, catalog, and STAC endpoints can be found in the [Carbon Mapper platform API documentation](https://carbonmapper.org/api/v1/docs/).\n",
     "\n",
+    "The scoped API token is only provided to the user once, upon generation. If generating the token for future use, it should be stored securely for future use, and should not be committed to code repositories.\n",
+    "\n",
     "Users with Carbon Mapper platform accounts may obtain a scoped token. Users without accounts can [register](https://platform.carbonmapper.org/account/register/) on the Carbon Mapper platform website. "
-   ],
-   "id": "b4fe2ffde6eb93d3"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
-   "outputs": [],
    "execution_count": null,
+   "id": "2495a407c06be64a",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "import getpass\n",
     "import json\n",
@@ -63,9 +66,9 @@
     ")\n",
     "response.raise_for_status()\n",
     "\n",
+    "# Values from the response can be stored in variables or saved for use in other scripts\n",
     "print(json.dumps(response.json(), indent=4))"
-   ],
-   "id": "2495a407c06be64a"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
Demonstration of requesting a scoped token with STAC privileges using an access token. Rendered notebook can be viewed [here](https://github.com/carbon-mapper/platform-public/blob/d45bca762fc330df4c7762565ebc0b6b8c9a9fd7/tutorials/stac_token.ipynb)