### PR TITLE
Create L2B CMF download tutorial

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 jupyter==1.0.0
 requests==2.32.3
 fiona==1.9.6
+pickleshare==0.7.5
+pystac-client==0.8.3

--- a/tutorials/plumes.ipynb
+++ b/tutorials/plumes.ipynb
@@ -2,18 +2,10 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "d04f0211-77f2-4812-bfea-d83a5a8063b1",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdin",
-     "output_type": "stream",
-     "text": [
-      "Enter your Carbon Mapper API token. ········\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import getpass\n",
     "\n",
@@ -37,57 +29,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "073ae443-6675-4323-8b19-9ce3a650812b",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Plumes discovered: 1570\n",
-      "{\n",
-      "    \"id\": \"5153b52c-a61c-40eb-a546-6a915f7b9249\",\n",
-      "    \"plume_id\": \"emi20231201t201023p13003-A\",\n",
-      "    \"gas\": \"CH4\",\n",
-      "    \"geometry_json\": {\n",
-      "        \"bbox\": null,\n",
-      "        \"type\": \"Point\",\n",
-      "        \"coordinates\": [\n",
-      "            -119.46355531510318,\n",
-      "            36.04328190922341\n",
-      "        ]\n",
-      "    },\n",
-      "    \"scene_id\": \"ec53c12d-a526-4060-835e-7fd20852b61d\",\n",
-      "    \"scene_timestamp\": \"2023-12-01T20:10:23Z\",\n",
-      "    \"instrument\": \"emi\",\n",
-      "    \"platform\": \"ISS\",\n",
-      "    \"emission_auto\": null,\n",
-      "    \"emission_uncertainty_auto\": null,\n",
-      "    \"plume_png\": \"https://carbon-mapper-data.s3.amazonaws.com/l3a-vis-ch4-mfa-v1/2023/12/01/emi20231201t201023p13003-A/emi20231201t201023p13003-A_l3a-vis-ch4-mfa-v1_plume.png?AWSAccessKeyId=AKIAZ6GFKVV6SHEMM55U&Signature=0DkWvHjJJlTZh2BjuIua4I7KlUg%3D&Expires=1723588021\",\n",
-      "    \"plume_rgb_png\": \"https://carbon-mapper-data.s3.amazonaws.com/l3a-vis-ch4-mfa-v1/2023/12/01/emi20231201t201023p13003-A/emi20231201t201023p13003-A_l3a-vis-ch4-mfa-v1_plume-rgb.png?AWSAccessKeyId=AKIAZ6GFKVV6SHEMM55U&Signature=Z8Pe8%2Bdwvl7rVHvJHKwHf7A1fGk%3D&Expires=1723588021\",\n",
-      "    \"plume_tif\": \"https://carbon-mapper-data.s3.amazonaws.com/l3a-vis-ch4-mfa-v1/2023/12/01/emi20231201t201023p13003-A/emi20231201t201023p13003-A_l3a-vis-ch4-mfa-v1_plume.tif?AWSAccessKeyId=AKIAZ6GFKVV6SHEMM55U&Signature=fdXdnpxCvuPayIoI4IBOU%2BvqhOA%3D&Expires=1723588021\",\n",
-      "    \"con_tif\": null,\n",
-      "    \"rgb_png\": \"https://carbon-mapper-data.s3.amazonaws.com/l3a-vis-ch4-mfa-v1/2023/12/01/emi20231201t201023p13003-A/emi20231201t201023p13003-A_l3a-vis-ch4-mfa-v1_rgb.png?AWSAccessKeyId=AKIAZ6GFKVV6SHEMM55U&Signature=6tMLn%2BFE0Lf8L1BXyDFELmJaCAw%3D&Expires=1723588021\",\n",
-      "    \"plume_bounds\": [\n",
-      "        -119.53051371773019,\n",
-      "        35.98970692014497,\n",
-      "        -119.39399960218326,\n",
-      "        36.099606639320825\n",
-      "    ],\n",
-      "    \"plume_quality\": null,\n",
-      "    \"wind_speed_avg_auto\": null,\n",
-      "    \"wind_direction_avg_auto\": null,\n",
-      "    \"collection\": \"l2c-ch4-v0\",\n",
-      "    \"cmf_type\": \"mfa\",\n",
-      "    \"sector\": \"4B\",\n",
-      "    \"status\": \"published\",\n",
-      "    \"hide_emission\": true,\n",
-      "    \"published_at\": \"2024-02-13T19:57:10.883Z\"\n",
-      "}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import json\n",
     "import requests\n",

--- a/tutorials/plumes.ipynb
+++ b/tutorials/plumes.ipynb
@@ -2,10 +2,18 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "d04f0211-77f2-4812-bfea-d83a5a8063b1",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "Enter your Carbon Mapper API token. ········\n"
+     ]
+    }
+   ],
    "source": [
     "import getpass\n",
     "\n",
@@ -29,10 +37,57 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "073ae443-6675-4323-8b19-9ce3a650812b",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Plumes discovered: 1570\n",
+      "{\n",
+      "    \"id\": \"5153b52c-a61c-40eb-a546-6a915f7b9249\",\n",
+      "    \"plume_id\": \"emi20231201t201023p13003-A\",\n",
+      "    \"gas\": \"CH4\",\n",
+      "    \"geometry_json\": {\n",
+      "        \"bbox\": null,\n",
+      "        \"type\": \"Point\",\n",
+      "        \"coordinates\": [\n",
+      "            -119.46355531510318,\n",
+      "            36.04328190922341\n",
+      "        ]\n",
+      "    },\n",
+      "    \"scene_id\": \"ec53c12d-a526-4060-835e-7fd20852b61d\",\n",
+      "    \"scene_timestamp\": \"2023-12-01T20:10:23Z\",\n",
+      "    \"instrument\": \"emi\",\n",
+      "    \"platform\": \"ISS\",\n",
+      "    \"emission_auto\": null,\n",
+      "    \"emission_uncertainty_auto\": null,\n",
+      "    \"plume_png\": \"https://carbon-mapper-data.s3.amazonaws.com/l3a-vis-ch4-mfa-v1/2023/12/01/emi20231201t201023p13003-A/emi20231201t201023p13003-A_l3a-vis-ch4-mfa-v1_plume.png?AWSAccessKeyId=AKIAZ6GFKVV6SHEMM55U&Signature=0DkWvHjJJlTZh2BjuIua4I7KlUg%3D&Expires=1723588021\",\n",
+      "    \"plume_rgb_png\": \"https://carbon-mapper-data.s3.amazonaws.com/l3a-vis-ch4-mfa-v1/2023/12/01/emi20231201t201023p13003-A/emi20231201t201023p13003-A_l3a-vis-ch4-mfa-v1_plume-rgb.png?AWSAccessKeyId=AKIAZ6GFKVV6SHEMM55U&Signature=Z8Pe8%2Bdwvl7rVHvJHKwHf7A1fGk%3D&Expires=1723588021\",\n",
+      "    \"plume_tif\": \"https://carbon-mapper-data.s3.amazonaws.com/l3a-vis-ch4-mfa-v1/2023/12/01/emi20231201t201023p13003-A/emi20231201t201023p13003-A_l3a-vis-ch4-mfa-v1_plume.tif?AWSAccessKeyId=AKIAZ6GFKVV6SHEMM55U&Signature=fdXdnpxCvuPayIoI4IBOU%2BvqhOA%3D&Expires=1723588021\",\n",
+      "    \"con_tif\": null,\n",
+      "    \"rgb_png\": \"https://carbon-mapper-data.s3.amazonaws.com/l3a-vis-ch4-mfa-v1/2023/12/01/emi20231201t201023p13003-A/emi20231201t201023p13003-A_l3a-vis-ch4-mfa-v1_rgb.png?AWSAccessKeyId=AKIAZ6GFKVV6SHEMM55U&Signature=6tMLn%2BFE0Lf8L1BXyDFELmJaCAw%3D&Expires=1723588021\",\n",
+      "    \"plume_bounds\": [\n",
+      "        -119.53051371773019,\n",
+      "        35.98970692014497,\n",
+      "        -119.39399960218326,\n",
+      "        36.099606639320825\n",
+      "    ],\n",
+      "    \"plume_quality\": null,\n",
+      "    \"wind_speed_avg_auto\": null,\n",
+      "    \"wind_direction_avg_auto\": null,\n",
+      "    \"collection\": \"l2c-ch4-v0\",\n",
+      "    \"cmf_type\": \"mfa\",\n",
+      "    \"sector\": \"4B\",\n",
+      "    \"status\": \"published\",\n",
+      "    \"hide_emission\": true,\n",
+      "    \"published_at\": \"2024-02-13T19:57:10.883Z\"\n",
+      "}\n"
+     ]
+    }
+   ],
    "source": [
     "import json\n",
     "import requests\n",

--- a/tutorials/stac/downloading_l2b_cmf_asset.ipynb
+++ b/tutorials/stac/downloading_l2b_cmf_asset.ipynb
@@ -1,0 +1,159 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "7e9b8d25-0835-4fce-bd2e-29de981c28ee",
+   "metadata": {},
+   "source": [
+    "# Downloading an L2B CMF Asset\n",
+    "\n",
+    "This tutorial provides steps to download an L2B CMF asset using the Carbon Mapper platform STAC API.\n",
+    "\n",
+    "## Authenticating\n",
+    "\n",
+    "While many Carbon Mapper platform STAC API resources do not require authentication to access, some resources, such as asset downloads, do. This tutorial will require authentication, and so will require a scoped token with STAC privileges. The [STAC token tutorial](https://github.com/carbon-mapper/platform-public/blob/main/tutorials/stac_token.ipynb) provides a proces to create, store, and print a scoped token. The STAC token tutorial can be used to store the token with IPython. If the token exists in IPython storage, we ask to use it. If it hasn't been stored, or the user declines to use it, we ask the user to provide a token.\n",
+    "\n",
+    "Information about manually creating a scoped token can be found in the tutorials [README](https://github.com/carbon-mapper/platform-public/tree/main/tutorials#api-authentication)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "180617dd-16f4-4a12-8a8f-b93178b265e9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Retrieve IPython storage\n",
+    "%store -r\n",
+    "\n",
+    "# Try to get a scoped token\n",
+    "try:\n",
+    "    token = cm_scoped_token[\"token_value\"]\n",
+    "except NameError:\n",
+    "    token = None\n",
+    "else:\n",
+    "    if input(\"Existing scoped token found in IPython storage. Would you like to use it? (Y/n)? \").lower() != \"y\":\n",
+    "        token = None\n",
+    "finally:\n",
+    "    if not token:\n",
+    "        token = input(\"Enter your Carbon Mapper platform API scoped token: \")\n",
+    "\n",
+    "if not token:\n",
+    "    raise ValueError(\"A scoped token is required for this tutorial.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "191dc133-012c-4642-9d9f-0f61d76f8152",
+   "metadata": {},
+   "source": [
+    "## Initalizing the Client\n",
+    "\n",
+    "After a token is provided we can set the catalog URL, initialize PySTAC-Client, and print any errors that occur."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1cfb042d-e61b-4653-9325-492178999779",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "\n",
+    "from pystac_client import Client\n",
+    "from pystac_client.exceptions import APIError\n",
+    "\n",
+    "catalog_url = \"https://api.carbonmapper.org/api/v1/stac/\"\n",
+    "headers = {\"Authorization\": f\"Bearer {token}\"}\n",
+    "\n",
+    "\n",
+    "try:\n",
+    "    catalog = Client.open(catalog_url, headers=headers)\n",
+    "except APIError as e:\n",
+    "    for message in json.loads(str(e))[\"messages\"]:\n",
+    "        print(\"Error:\", message[\"message\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "45cc9457-ff75-44ce-86d6-3b6220574bd4",
+   "metadata": {},
+   "source": [
+    "## Downloading a Concentration Matched Filter (CMF) Asset\n",
+    "\n",
+    "With the previous steps successful, we are now ready to use the Level 2B CO<sub>2</sub> FeatureCollection resource to download a CMF asset. We will review the available L2B collections, search for L2B CO<sub>2</sub> features using a simplified GeoJSON representation of the state of California, and then download a CMF asset from the first result."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "13af0919-11a5-4d59-abba-6b1739c051d8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import requests\n",
+    "from pathlib import Path, PurePath\n",
+    "from urllib.parse import urlparse\n",
+    "\n",
+    "collections = catalog.get_collections()\n",
+    "print(\"L2B collections:\\n\")\n",
+    "\n",
+    "for collection in collections:\n",
+    "    if \"l2b\" in collection.id:\n",
+    "        print(f\"\\t{collection.id}\")\n",
+    "\n",
+    "aoi_geojson = '{\"type\": \"MultiPolygon\", \"coordinates\": [[[[-120.248484, 33.999329], [-120.043259, 34.035806], [-119.97026, 33.944359], [-120.121817, 33.895712], [-120.248484, 33.999329]]], [[[-119.789798, 34.05726], [-119.637742, 34.013178], [-119.52064, 34.034262], [-119.758141, 33.959212], [-119.923337, 34.069361], [-119.789798, 34.05726]]], [[[-120.46258, 34.042627], [-120.368278, 34.076465], [-120.302122, 34.023574], [-120.35793, 34.015029], [-120.46258, 34.042627]]], [[[-119.543842, 33.280329], [-119.465717, 33.259239], [-119.429559, 33.228167], [-119.545872, 33.233406], [-119.543842, 33.280329]]], [[[-119.422972, 34.004368], [-119.441226, 34.014075], [-119.357462, 34.015919], [-119.391551, 34.002505], [-119.422972, 34.004368]]], [[[-118.524531, 32.895488], [-118.605534, 33.030999], [-118.353504, 32.821962], [-118.425634, 32.800595], [-118.524531, 32.895488]]], [[[-118.500212, 33.449592], [-118.370323, 33.409285], [-118.305084, 33.310323], [-118.60403, 33.47654], [-118.500212, 33.449592]]], [[[-122.418698, 37.852717], [-122.434403, 37.852434], [-122.446316, 37.861046], [-122.421341, 37.869946], [-122.418698, 37.852717]]], [[[-123.013916, 37.700355], [-123.004489, 37.706262], [-122.997189, 37.697909], [-123.005543, 37.689392], [-123.013916, 37.700355]]], [[[-122.3785, 37.826505], [-122.369941, 37.832137], [-122.362661, 37.807577], [-122.372422, 37.811301], [-122.3785, 37.826505]]], [[[-124.065521, 41.464739], [-124.211605, 41.99846], [-119.999168, 41.99454], [-120.001014, 38.999574], [-114.633013, 35.002085], [-114.131489, 34.260387], [-114.43338, 34.088413], [-114.535664, 33.568788], [-114.721233, 33.396912], [-114.496284, 32.822326], [-117.124862, 32.534156], [-117.469794, 33.296417], [-118.132698, 33.753217], [-118.411211, 33.741985], [-118.519514, 34.027509], [-119.130169, 34.100102], [-119.559459, 34.413395], [-120.637805, 34.56622], [-120.644311, 35.139616], [-121.888491, 36.30281], [-121.978592, 36.580488], [-121.814462, 36.682858], [-121.862266, 36.931552], [-122.405073, 37.195791], [-122.514483, 37.780829], [-122.111344, 37.50758], [-122.430087, 37.963115], [-122.273006, 38.07438], [-122.489974, 38.112014], [-122.505383, 37.822128], [-123.024066, 37.994878], [-122.977082, 38.267902], [-123.725367, 38.917438], [-123.851714, 39.832041], [-124.409591, 40.438076], [-124.137066, 40.925732], [-124.065521, 41.464739]]]]}'\n",
+    "# Limit max_items to reduce streaming time\n",
+    "search = catalog.search(max_items=5, intersects=aoi_geojson, collections=\"l2b-co2\", method=\"GET\")\n",
+    "items = list(search.items_as_dicts())\n",
+    "item_cmf_asset_url = items[0][\"assets\"][\"cmf.tif\"][\"href\"]\n",
+    "\n",
+    "print(\"\\n\", len(items), \"items found.\")\n",
+    "\n",
+    "# Download the asset\n",
+    "response = requests.get(item_cmf_asset_url, headers=headers)\n",
+    "\n",
+    "# If empty, will save to current working directory\n",
+    "file_path = Path(\"\")\n",
+    "# Get filename from download asset URL\n",
+    "file_name = PurePath(urlparse(item_cmf_asset_url).path).name\n",
+    "abs_path = os.path.abspath(file_path / file_name)\n",
+    "\n",
+    "confirm = input(\"{action} file ({abs_path})? Y/n\".format(\n",
+    "    action=\"Overwrite\" if Path(abs_path).is_file() else \"Save\",\n",
+    "    abs_path=abs_path,\n",
+    "))\n",
+    "\n",
+    "if confirm.lower() == \"y\":\n",
+    "    # Save the asset to disk\n",
+    "    with open(abs_path, \"wb\") as file:\n",
+    "        file.write(response.content)\n",
+    "\n",
+    "    print(f\"Asset downloaded to {abs_path}.\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tutorials/stac/downloading_l2b_cmf_asset.ipynb
+++ b/tutorials/stac/downloading_l2b_cmf_asset.ipynb
@@ -5,7 +5,7 @@
    "id": "7e9b8d25-0835-4fce-bd2e-29de981c28ee",
    "metadata": {},
    "source": [
-    "# Downloading an L2B CMF Asset\n",
+    "# Downloading an L2B Column-Wise Matched Filter (CMF) Asset\n",
     "\n",
     "This tutorial provides steps to download an L2B CMF asset using the Carbon Mapper platform STAC API.\n",
     "\n",
@@ -80,7 +80,7 @@
    "id": "45cc9457-ff75-44ce-86d6-3b6220574bd4",
    "metadata": {},
    "source": [
-    "## Downloading a Concentration Matched Filter (CMF) Asset\n",
+    "## Downloading a CMF Asset\n",
     "\n",
     "With the previous steps successful, we are now ready to use the Level 2B CO<sub>2</sub> FeatureCollection resource to download a CMF asset. We will review the available L2B collections, search for L2B CO<sub>2</sub> features using a simplified GeoJSON representation of the state of California, and then download a CMF asset from the first result."
    ]

--- a/tutorials/stac_token.ipynb
+++ b/tutorials/stac_token.ipynb
@@ -7,9 +7,9 @@
    "source": [
     "# Requesting a scoped API Token With STAC Privileges\n",
     "\n",
-    "In this tutorial, we will request an access token from the platform API, and then request a scoped API token with STAC privileges from the [create STAC token](https://api.carbonmapper.org/api/v1/docs#/Account/account_api_token_tokens_create_stac) endpoint.\n",
+    "In this tutorial, we will request an access token from the platform API, and then request a scoped API token with STAC privileges from the [create STAC token](https://api.carbonmapper.org/api/v1/docs#/Account/account_api_token_tokens_create_stac) resource.\n",
     "\n",
-    "Endpoint access levels are determined by token scopes. While some endpoints are entirely public and others private, some others return different results depending on the authorization afforded by the token scope and the group that the account belongs to. The default scopes provided to a newly registered account are _STAC_ and _catalog:read_, and will belong to the _Public_ group. Information about public, catalog, and STAC endpoints can be found in the [Carbon Mapper platform API documentation](https://carbonmapper.org/api/v1/docs/).\n",
+    "Resource access is granted based on token scopes. While some resources are entirely public and others private, some others return different results depending on the authorization afforded by the token scope and the group that the account belongs to. The default scopes provided to a newly registered account are _STAC_ and _catalog:read_, and will belong to the _Public_ group. Information about public, catalog, and STAC resources can be found in the [Carbon Mapper platform API documentation](https://api.carbonmapper.org/).\n",
     "\n",
     "The scoped API token is only provided to the user once, upon generation. If generating the token for future use, it should be stored securely for future use, and should not be committed to code repositories.\n",
     "\n",
@@ -66,8 +66,15 @@
     ")\n",
     "response.raise_for_status()\n",
     "\n",
-    "# Values from the response can be stored in variables or saved for use in other scripts\n",
-    "print(json.dumps(response.json(), indent=4))"
+    "# Assign scoped token to a variable \n",
+    "cm_scoped_token = response.json()\n",
+    "\n",
+    "# Store scoped token for use in other notebooks\n",
+    "if input(\"Store scoped token for use in other notebooks? Y/n \").lower() == \"y\":\n",
+    "    %store cm_scoped_token\n",
+    "\n",
+    "# Print scoped token for other uses\n",
+    "print(json.dumps(cm_scoped_token, indent=4))"
    ]
   }
  ],

--- a/tutorials/stac_token.ipynb
+++ b/tutorials/stac_token.ipynb
@@ -11,7 +11,7 @@
     "\n",
     "Resource access is granted based on token scopes. While some resources are entirely public and others private, some others return different results depending on the authorization afforded by the token scope and the group that the account belongs to. The default scopes provided to a newly registered account are _STAC_ and _catalog:read_, and will belong to the _Public_ group. Information about public, catalog, and STAC resources can be found in the [Carbon Mapper platform API documentation](https://api.carbonmapper.org/).\n",
     "\n",
-    "The scoped API token is only provided to the user once, upon generation. If generating the token for future use, it should be stored securely for future use, and should not be committed to code repositories.\n",
+    "The scoped API token is only provided to the user once, upon generation. If generating the token for future use, it should be stored securely and should not be committed to code repositories.\n",
     "\n",
     "Users with Carbon Mapper platform accounts may obtain a scoped token. Users without accounts can [register](https://platform.carbonmapper.org/account/register/) on the Carbon Mapper platform website. "
    ]


### PR DESCRIPTION
* adds an [L2B CMF download tutorial](https://github.com/carbon-mapper/platform-public/blob/84206f4ff8f0abec05b396c853c142a5e32d1a25/tutorials/stac/downloading_l2b_cmf_asset.ipynb)
* updates [STAC token tutorial](https://github.com/carbon-mapper/platform-public/blob/84206f4ff8f0abec05b396c853c142a5e32d1a25/tutorials/stac_token.ipynb) to use magicstore and refines some language
* adds pystac-client and pickleshare to requirements