### PR TITLE
Add crs and layer name to gpkg

### DIFF
--- a/tutorials/download_scenes_geopackage.ipynb
+++ b/tutorials/download_scenes_geopackage.ipynb
@@ -127,7 +127,7 @@
     "\n",
     "with MemoryFile() as dst_file:\n",
     "    # Instantiate an  in-memory GeoPackage using the previously retrieved schema\n",
-    "    with dst_file.open(mode=\"w\", driver=\"GPKG\", schema=schema) as dst_collection:\n",
+    "    with dst_file.open(mode=\"w\", driver=\"GPKG\", schema=schema, layer=\"scenes\", crs=\"EPSG:4326\") as dst_collection:\n",
     "        while True:\n",
     "            # Download a page of features\n",
     "            response = requests.get(\n",


### PR DESCRIPTION
This is a small fix to apply a CRS and layer name to the GeoPackage created from the API. These should now display correctly in ArcMap and QGIS.